### PR TITLE
Added route to get the next cleaner

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -50,21 +50,30 @@ end
 
 DataMapper.finalize.auto_upgrade!
 
-get "/" do 
-  content_type :json
-  redirect to("/now")
-end
-
-get "/now" do
+def respond_cleaner_for_week(week)
   content_type :json
   info = Info.first || halt(404)
   cleaners = Cleaner.all(order: :sequence) || halt(404)
 
   now = Time.now
   today = Time.new(now.year, now.month, now.day)
-  offset = ((today - info.startdate.to_time) / ONE_WEEK) % cleaners.count
-  @cleaner = cleaners[offset.to_i]
+  index = (((today - info.startdate.to_time) / ONE_WEEK) + week) % cleaners.count
+  @cleaner = cleaners[index.to_i]
   @cleaner.to_json
+end
+
+get "/" do 
+  content_type :json
+  redirect to("/now")
+end
+
+get "/now" do
+  respond_cleaner_for_week 0
+end
+
+get "/next/?:week?" do
+  week = params[:week] ? params[:week].to_i : 1
+  respond_cleaner_for_week week
 end
 
 put "/cleaners" do

--- a/test.rb
+++ b/test.rb
@@ -45,4 +45,44 @@ class KleanoalaTest < Test::Unit::TestCase
     assert @browser.last_response.ok?
     assert JSON.parse(@browser.last_response.body)
   end
+
+  def test_it_can_get_the_cleaner_for_next_week
+    @browser = Rack::Test::Session.new(Rack::MockSession.new(Sinatra::Application))
+
+    data = {startdate: "2015/12/25", cleaners: [ "one", "two", "three" ] }.to_json
+    basic_authorize "admin", ENV["ADMIN_PASSWORD"]
+    @browser.put "/cleaners", data, "Content-Type" => "application/json"
+
+    @browser.get "/next"
+    assert @browser.last_response.ok?
+    assert JSON.parse(@browser.last_response.body)
+  end
+
+  def test_it_can_get_the_cleaner_for_week_x
+    @browser = Rack::Test::Session.new(Rack::MockSession.new(Sinatra::Application))
+
+    data = {startdate: "2015/12/25", cleaners: [ "one", "two", "three" ] }.to_json
+    basic_authorize "admin", ENV["ADMIN_PASSWORD"]
+    @browser.put "/cleaners", data, "Content-Type" => "application/json"
+
+    [ 2, 3, 10, 100, 1000].each do |offset|
+      @browser.get "/next/#{offset}"
+      assert @browser.last_response.ok?
+      assert JSON.parse(@browser.last_response.body)
+    end
+  end
+
+  def test_it_returns_same_cleaner_for_week_1_and_next
+    @browser = Rack::Test::Session.new(Rack::MockSession.new(Sinatra::Application))
+
+    data = {startdate: "2015/12/25", cleaners: [ "one", "two", "three" ] }.to_json
+    basic_authorize "admin", ENV["ADMIN_PASSWORD"]
+    @browser.put "/cleaners", data, "Content-Type" => "application/json"
+
+    @browser.get "/next"
+    val = JSON.parse(@browser.last_response.body)[:name]
+
+    @browser.get "/next/1"
+    assert_equal val, JSON.parse(@browser.last_response.body)[:name]
+  end
 end


### PR DESCRIPTION
Routes `/next` and `/next/x` will return the cleaner for next week or
week "x".

Fixes #2 .
